### PR TITLE
Fix compilation error for get_mut_or_tagged_slot function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cristi Cobzarenco <cristi.cobzarenco@gmail.com>"]
 name = "idcontain"
-version = "0.7.5"
+version = "0.7.6"
 
 description = "Generational (or tagged) ID-based containers."
 homepage = "https://github.com/cristicbz/idcontain.rs"

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -452,24 +452,18 @@ impl<T> IdSlab<T> {
     }
 
     fn get_mut_or_tagged_slot(&mut self, id: Id<T>) -> Result<&mut T, Option<&mut TaggedSlot<T>>> {
-        let tagged_slot = self.slots.get_mut(id.index as usize).ok_or(None)?;
-        match *tagged_slot {
-            TaggedSlot {
-                slot: Slot::Occupied { .. },
-                tag,
-            } if tag == id.tag => {
-                // We can not just return the inner value here because `*tagged_slot`
-                // would be considered borrowed until the end of the entire function.
-                // But it needs to be borrowed in the next match handle.
-                // That's why we have to re-match it.
-                match *tagged_slot {
-                    TaggedSlot {
-                        slot: Slot::Occupied { ref mut value }, ..
-                    } => Ok(value),
-                    _ => unreachable!(),
+        match self.slots.get_mut(id.index as usize) {
+            Some(tagged_slot) => {
+                if id.tag == tagged_slot.tag {
+                    match tagged_slot.slot {
+                        Slot::Occupied { ref mut value } => Ok(value),
+                        _ => Err(Some(tagged_slot)),
+                    }
+                } else {
+                    Err(Some(tagged_slot))
                 }
-            },
-            _ => Err(Some(tagged_slot)),
+            }
+            _ => Err(None),
         }
     }
 


### PR DESCRIPTION
Build in stable branch was failing with an error:
```
error[E0505]: cannot move out of `_` because it is borrowed
   --> src/slab.rs:460:13
    |
454 |     fn get_mut_or_tagged_slot(&mut self, id: Id<T>) -> Result<&mut T, Option<&mut TaggedSlot<T>>> {
    |                               - let's call the lifetime of this reference `'1`
...
457 |                 slot: Slot::Occupied { ref mut value },
    |                                        ------------- borrow of value occurs here
458 |                 tag,
459 |             }) if tag == id.tag => Ok(value),
    |                                    --------- returning this value requires that borrow lasts for `'1`
460 |             tagged_slot => Err(tagged_slot),
    |             ^^^^^^^^^^^ move out of value occurs here
```

Explanation of a similar problem can be found [here](https://github.com/rust-lang/rust/issues/21906#issuecomment-303258612).
This is the least messy fix that I could come up with.

Interestingly, there is no such problem with a `get_or_tagged_slot` function only because multiple non-mutable borrows of the same value are allowed.

BTW, should I bump the package version with this PR?